### PR TITLE
fix: redundante API-Calls in Footer und JobOfferBanner via cached() v…

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,10 +1,11 @@
 ---
 import { getConfigByID, getWisdoms } from "../lib/API";
 import { CONTENTFUL_IDS } from "../lib/constants";
+import { cached } from "../lib/cached";
 import type { Config, Wisdom } from "../lib/types";
 
-const navigation: Config = await getConfigByID(CONTENTFUL_IDS.navigation);
-const wisdoms: Wisdom[] = await getWisdoms();
+const navigation: Config = await cached("navigation", () => getConfigByID(CONTENTFUL_IDS.navigation));
+const wisdoms: Wisdom[] = await cached("wisdoms", getWisdoms);
 
 // ⚡ Zufallszahl-Generator
 function getRandomInteger(min: number, max: number): number {

--- a/src/components/JobOfferBanner.astro
+++ b/src/components/JobOfferBanner.astro
@@ -1,10 +1,10 @@
 ---
 import { getConfigByID, getPageByID } from "../lib/API";
 import { CONTENTFUL_IDS } from "../lib/constants";
+import { cached } from "../lib/cached";
 
-const { data } = await getConfigByID(CONTENTFUL_IDS.settings);
-
-const jobOfferBanner = await getPageByID(data.jobOfferID);
+const { data } = await cached("settings", () => getConfigByID(CONTENTFUL_IDS.settings));
+const jobOfferBanner = await cached("jobOfferBanner", () => getPageByID(data.jobOfferID));
 ---
 
 {


### PR DESCRIPTION
…ermieden

Settings, Navigation, Wisdoms und JobOffer-Banner werden jetzt gecacht — gleiche Keys wie in index.astro, sodass pro Build nur ein API-Call je Ressource stattfindet.