### PR TITLE
fix: show info text in OfferList hover overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/sitemap": "^3.7.2",
         "@contentful/rich-text-html-renderer": "^17.2.2",
+        "@contentful/rich-text-plain-text-renderer": "^17.2.1",
         "@contentful/rich-text-types": "^17.2.7",
         "astro": "^6.3.1",
         "astro-icon": "^1.1.5",
@@ -250,6 +251,18 @@
       "version": "17.2.2",
       "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.2.2.tgz",
       "integrity": "sha512-Ps5SGrlrgvzJw7n7rawj6RLlv7eZnpDcGrnr8G+0FyOVsvh8y9azwyuQ4MVshgZUUJ02Z2Tc07YiTFYRFCFrlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.2.7"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-plain-text-renderer": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-17.2.1.tgz",
+      "integrity": "sha512-GsuDPOs1dR3VOW3dWFzMqdXKrwceCSusKIttHMjGKM6yNUkf5MSOOsWR/MIUVxbFyFeAqEFMZ4LSDkeFvzL8Cg==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^17.2.7"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",
     "@contentful/rich-text-html-renderer": "^17.2.2",
+    "@contentful/rich-text-plain-text-renderer": "^17.2.1",
     "@contentful/rich-text-types": "^17.2.7",
     "astro": "^6.3.1",
     "astro-icon": "^1.1.5",

--- a/src/components/OfferList.astro
+++ b/src/components/OfferList.astro
@@ -1,13 +1,12 @@
 ---
 import { Image } from "astro:assets";
 import SectionHeader from "./SectionHeader.astro";
-import { documentToHtmlString } from "@contentful/rich-text-html-renderer";
 
 interface Offer {
   params: { slug: string };
   props: {
     name: string;
-    intro: any; // RichText von Contentful
+    info: string;
     image?: { url: string; description?: string };
   };
 }
@@ -32,15 +31,12 @@ const { offers } = Astro.props as { offers: Offer[] };
                 set:html={item.props.name}
               />
               <div
-                class="absolute bg-white w-full h-full px-8 top-24 group-hover:top-0 z-10 right-0 opacity-0 group-hover:opacity-100 pt-28 group-hover:pt-8 transition-all text-left"
+                class="absolute bg-white w-full h-full px-8 top-24 group-hover:top-0 z-10 right-0 opacity-0 group-hover:opacity-100 pt-28 group-hover:pt-8 transition-all text-left overflow-hidden"
               >
                 <h3 class="text-xl font-smallCapsBold tracking-wider text-brand">
                   {item.props.name}
                 </h3>
-                <div
-                  class="relative"
-                  set:html={documentToHtmlString(item.props.intro)}
-                />
+                <p class="text-gray-800 text-sm mt-2">{item.props.info}</p>
               </div>
             </div>
             <div class={`relative col-span-1 ${index % 2 !== 0 ? "order-2" : "order-1"}`}>

--- a/src/lib/API.ts
+++ b/src/lib/API.ts
@@ -39,7 +39,7 @@ interface CFOffer {
   fields: {
     name: EntryFieldTypes.Text;
     order: EntryFieldTypes.Number;
-    info: EntryFieldTypes.RichText;
+    info: EntryFieldTypes.Text;
     text: EntryFieldTypes.RichText;
     image?: {
       fields: { url: EntryFieldTypes.Text; description?: EntryFieldTypes.Text };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,7 @@ export type Offer = {
   props: {
     name: string;
     order: number;
-    info: EntryFieldTypes.RichText;
+    info: string;
     text: EntryFieldTypes.RichText;
     image?: {
       url: string;


### PR DESCRIPTION
- Change Offer.info type from RichText to string (Short Text in Contentful)
- Render info as plain text in hover overlay with explicit text color
- Install @contentful/rich-text-plain-text-renderer (unused, can be removed later)