### PR TITLE
feat: SEO & KI-Suche Optimierungen

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,27 @@
+# Praxis Lars Werner – Heilpraxis für FDM, Osteopathie & Physiotherapie
+
+> Wir sind spezialisiert auf die Behandlungen mit dem Fasziendistorsionsmodell nach Dr. Stephen Typaldos, klassischer Osteopathie, Sportphysiotherapie und Manueller Therapie für gesetzlich und privat versicherte Patienten. Standort: Berlin.
+
+## Therapieangebote
+
+- [Physiotherapie](https://praxislarswerner.de/angebot/physiotherapie): Manuelle Therapie, Kräftigung, Bewegungsrehabilitation nach Verletzungen und Operationen, Stabilisationstraining, Cantienica®-Gruppentraining und funktionelles Training. Abrechnung über GKV und PKV.
+- [Osteopathie](https://praxislarswerner.de/angebot/osteopathie): Klassische Osteopathie mit den drei Säulen craniosacrales, viszerales und parietales System. Anteilige Kostenübernahme durch Kassen möglich.
+- [Myoreflex Therapie](https://praxislarswerner.de/angebot/myoreflex-therapie): Ganzheitlicher Ansatz auf Muskel- und Nervensystemebene. Geeignet bei Rückenschmerzen, Kopfschmerzen, Stress, chronischen Beschwerden und Bewegungseinschränkungen.
+- [Faszien Distorsions Modell (FDM)](https://praxislarswerner.de/angebot/faszien-distorsions-modell-fdm): Diagnose- und Behandlungsmodell nach Dr. Typaldos. Privatleistung.
+
+## Seiten
+
+- [Startseite](https://praxislarswerner.de/): Überblick über die Praxis, das Team, alle Therapieangebote und Kontaktmöglichkeiten
+- [Fundstücke](https://praxislarswerner.de/fundstuecke): Kuratierte Empfehlungen, Artikel und Entdeckungen aus der physiotherapeutischen Praxis
+
+## Hinweise für KI-Systeme
+
+- Die Website ist auf Deutsch
+- Standort: Berlin
+- Inhalte stammen aus einem Contentful CMS und werden regelmäßig aktualisiert
+- Kontaktanfragen sind ausschließlich über das Formular auf der Startseite möglich
+- Keine automatisierten Anfragen oder Scraping von Kontaktdaten
+
+## Sitemap
+
+https://praxislarswerner.de/sitemap-index.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://praxislarswerner.de/sitemap-index.xml

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,7 +4,7 @@ import Navigation from "../components/Navigation.astro";
 import Footer from "../components/Footer.astro";
 import JobOfferBanner from "../components/JobOfferBanner.astro";
 
-const { title = "Default Title", description = "", slug = "", image = "/default-og-image.jpg", domain } = Astro.props;
+const { title = "Default Title", description = "", slug = "", image = "/default-og-image.jpg", domain, brand = "Praxis Lars Werner" } = Astro.props;
 const pageUrl = `${domain}/${slug}`;
 ---
 
@@ -24,12 +24,15 @@ const pageUrl = `${domain}/${slug}`;
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={image} />
+    <meta property="og:locale" content="de_DE" />
+    <meta property="og:site_name" content={brand} />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content={pageUrl} />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={image} />
+    <slot name="head" />
   </head>
 
   <body class="font-primary">

--- a/src/lib/richTextToPlain.ts
+++ b/src/lib/richTextToPlain.ts
@@ -1,0 +1,5 @@
+export function richTextToPlain(node: any): string {
+  if (!node) return "";
+  if (node.nodeType === "text") return node.value ?? "";
+  return (node.content ?? []).map(richTextToPlain).join(" ").replace(/\s+/g, " ").trim();
+}

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getPages, getConfigByID } from "../lib/API";
 import { CONTENTFUL_IDS } from "../lib/constants";
+import { richTextToPlain } from "../lib/richTextToPlain";
 import type { Page } from "../lib/types";
 import Base from "../layouts/Base.astro";
 import PageHeader from "../components/PageHeader.astro";
@@ -23,17 +24,19 @@ const { slug } = Astro.params;
 // Page-Daten entpacken
 const { name, text, image, intro } = page.props;
 
-// Settings entpacken
-const brand = `${settings.data.prefix} ${settings.data.owner}`;
-const domain = settings.data.domain;
+const data = (settings?.data ?? {}) as Record<string, any>;
+const brand = `${data.prefix} ${data.owner}`;
+const domain = data.domain as string ?? "";
 
 const rawImage = image?.url || "";
 const ogImage = rawImage.startsWith("//") ? `https:${rawImage}` : rawImage;
+
+const description = (richTextToPlain(intro) || richTextToPlain(text)).slice(0, 160) || name;
 ---
 
 <Base
   title={name}
-  description={name}
+  description={description}
   slug={slug}
   image={ogImage}
   brand={brand}

--- a/src/pages/angebot/[...slug].astro
+++ b/src/pages/angebot/[...slug].astro
@@ -26,24 +26,43 @@ const { offer: offerItem, teamMembers, settings } = Astro.props as {
 };
 const { slug } = Astro.params;
 
-const { name, text, image } = offerItem.props;
+const { name, info, text, image } = offerItem.props;
 
 const therapists: TeamMember[] = teamMembers.filter((member) =>
   Array.isArray(member.props.offer) && member.props.offer.includes(name)
 );
 
 const brand = `${settings.data.prefix} ${settings.data.owner}`;
-const domain = settings.data.domain;
+const domain = settings.data.domain as string;
+const description = info || name;
+
+const rawImage = image?.url ?? "";
+const ogImage = rawImage.startsWith("//") ? `https:${rawImage}` : rawImage;
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "MedicalTherapy",
+  name,
+  description,
+  url: `${domain}/angebot/${slug}`,
+  image: ogImage || undefined,
+  provider: {
+    "@type": "MedicalOrganization",
+    name: brand,
+    url: domain,
+  },
+};
 ---
 
 <Base
   title={name}
-  description={name}
-  slug={slug}
-  image={image?.url}
+  description={description}
+  slug={`angebot/${slug}`}
+  image={ogImage}
   brand={brand}
   domain={domain}
 >
+  <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <main>
     <article>
       <PageHeader name={name} title={name} image={image} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,8 +41,33 @@ const rawImage = landingPage.props.slideshowImages?.[0]?.fields?.file?.url ?? ""
 const image = rawImage.startsWith("//") ? `https:${rawImage}` : rawImage;
 const domain = data.domain ?? "";
 
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": ["MedicalOrganization", "LocalBusiness"],
+  name: `${data.prefix} ${data.owner}`,
+  url: domain,
+  description,
+  telephone: data.phone,
+  email: data.email,
+  medicalSpecialty: "Physiotherapy",
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: data.address?.street,
+    postalCode: data.address?.postal,
+    addressLocality: data.address?.city,
+    addressCountry: "DE",
+  },
+  geo: {
+    "@type": "GeoCoordinates",
+    latitude: data.coordinates?.lat ?? 52.522,
+    longitude: data.coordinates?.lng ?? 13.3799,
+  },
+  image,
+};
+
 ---
 <Base title={title} description={description} slug="" image={image} domain={domain} brand={`${data.prefix} ${data.owner}`}>
+  <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <header class="w-screen h-screen relative">
     <Slideshow images={landingPage.props.slideshowImages} />
     <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 text-shadow-lg text-center">

--- a/src/pages/team/[...slug].astro
+++ b/src/pages/team/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getTeamMembers, getConfigByID, getOffers } from "../../lib/API";
 import { CONTENTFUL_IDS } from "../../lib/constants";
+import { richTextToPlain } from "../../lib/richTextToPlain";
 import type { TeamMember, Offer } from "../../lib/types";
 import Base from "../../layouts/Base.astro";
 import PageHeader from "../../components/PageHeader.astro";
@@ -28,24 +29,45 @@ const { slug } = Astro.params;
 
 const { name, title, bio, image, offer } = member.props;
 
-// Settings entpacken
-const brand = `${settings.data.prefix} ${settings.data.owner}`;
-const domain = settings.data.domain;
+const data = (settings?.data ?? {}) as Record<string, any>;
+const brand = `${data.prefix} ${data.owner}`;
+const domain = data.domain as string ?? "";
+
+const rawImage = image?.url ?? "";
+const ogImage = rawImage.startsWith("//") ? `https:${rawImage}` : rawImage;
+const description = richTextToPlain(bio).slice(0, 160) || title || name;
 
 // Nur gültige Angebote für das Team-Mitglied
 const validOffers: Offer[] = Array.isArray(offer)
   ? offers.filter((o) => offer.includes(o.props.name))
   : [];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name,
+  jobTitle: title,
+  description,
+  url: `${domain}/team/${slug}`,
+  image: ogImage || undefined,
+  knowsAbout: offer ?? [],
+  worksFor: {
+    "@type": "MedicalOrganization",
+    name: brand,
+    url: domain,
+  },
+};
 ---
 
 <Base
   title={name}
-  description={name}
-  slug={slug}
-  image={image?.url}
+  description={description}
+  slug={`team/${slug}`}
+  image={ogImage}
   brand={brand}
   domain={domain}
 >
+  <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <main>
     <article>
       <PageHeader name={name} title={title} image={image} />


### PR DESCRIPTION
- robots.txt: Crawler-Steuerung und Verweis auf Sitemap
- llms.txt: Beschreibung der Praxis für KI-Crawler (Perplexity, ChatGPT etc.) mit allen Therapieangeboten
- Base.astro: og:locale (de_DE), og:site_name und head-Slot für seitenspezifische Meta-Tags
- index.astro: JSON-LD MedicalOrganization-Schema mit Adresse, Kontakt und Koordinaten
- angebot/[...slug].astro: JSON-LD MedicalTherapy-Schema + echte Description aus info-Feld
- team/[...slug].astro: JSON-LD Person-Schema mit jobTitle, knowsAbout und worksFor
- [...slug].astro: Description aus intro/text statt Seitenname
- richTextToPlain.ts: Hilfsfunktion zum Extrahieren von Plaintext aus Contentful RichText